### PR TITLE
Fix typos and update extraction message

### DIFF
--- a/NordLynxExtractKeys.sh
+++ b/NordLynxExtractKeys.sh
@@ -9,7 +9,7 @@ echo "== Setting NordVPN to use NordLynx =="
 nordvpn set technology NordLynx > /dev/null 2>&1
 echo "== Connecting to NordVPN Server =="
 nordvpn c $1 > /dev/null 2>&1
-echo "== Now extracting Wireguard Configurtion infomation =="
+echo "== Now extracting WireGuard configuration information =="
 current_server=$(nordvpn status | grep "Hostname:" |awk '{print $2}')
 public_key=$(sudo wg show | grep "public key")
 listening_port=$(sudo wg showconf nordlynx | grep "ListenPort")

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This script will:
 Once this is done, it will
 * Dump the information to the screen
 * Automatically disconnect from NordVPN
-* Dump the information into a file into the same directory as the sript using the currently connected server name.
+* Dump the information into a file into the same directory as the script using the currently connected server name.
 
 If you are using PfSense and Wireguard you can also follow this guide to help you set it up.
 


### PR DESCRIPTION
## Summary
- fix minor typos in README
- improve extraction message in NordLynxExtractKeys.sh

## Testing
- `bash -n NordLynxExtractKeys.sh`

------
https://chatgpt.com/codex/tasks/task_e_6867bcf217c48331a985611fb39a1517